### PR TITLE
Let a request content refuse to be built

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,16 @@ struct EchoRequestContent {
     greeting: String,
 }
 
-impl ApiRequestContent<Extensions> for EchoRequestContent {
+impl ApiRequestContent<Extensions, EchoFailure> for EchoRequestContent {
     type Data = EchoData;
-    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
+    fn create(
+        origin: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, EchoFailure> {
+        Ok(Self {
             id: origin.path.get("id").unwrap_or_default().to_owned(),
             data: origin.data_result,
             greeting: origin.extensions.greeting.clone(),
-        }
+        })
     }
 }
 
@@ -354,7 +356,7 @@ async fn logging(request: Mid, next: DFnOnce<Mid, MidRs>) -> MidRs {
 
 ## The API layer
 
-`ApiRequestContent<Extensions>` is the bridge from a raw request to your handler's argument. Its `create` gets everything the server knows:
+`ApiRequestContent<Extensions, Failure>` is the bridge from a raw request to your handler's argument. Its `create` gets everything the server knows:
 
 ```rust
 pub struct ApiRequestOriginContent<Data, Extensions> {
@@ -367,7 +369,22 @@ pub struct ApiRequestOriginContent<Data, Extensions> {
 }
 ```
 
-Body parsing is *not* fatal: `data_result` is a `DResult<Data>`, so a bad body reaches your handler as an `Err` and you decide the response. `()` implements `ApiRequestContent`, which is convenient for endpoints that ignore the request entirely.
+Body parsing is *not* fatal: `data_result` is a `DResult<Data>`, so a bad body reaches you as an `Err` and you decide the response — carry it into the handler, or `map_err` it into a failure right in `create`. `()` implements `ApiRequestContent`, which is convenient for endpoints that ignore the request entirely.
+
+`create` returns `Result<Self, Failure>`, and `Failure` is the failure half of the response the handler answers with, so a content that cannot be built — an id that will not parse, a missing header — refuses the request there and then: the handler is never called, and the client sees an ordinary failure response. A content written for one endpoint just names that endpoint's failure type; one meant to be reused stays generic over it, adding `From<…>` if it has an error of its own to convert:
+
+```rust
+impl<Extensions, Failure> ApiRequestContent<Extensions, Failure> for Authed
+where
+    Failure: ApiResponseContentFailure + From<AuthError>,
+{
+    type Data = ();
+    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Result<Self, Failure> {
+        let token = bearer_token(&origin.http_parts).ok_or(AuthError::Missing)?;
+        Ok(Self { token })
+    }
+}
+```
 
 On the way out, `ApiResponse<Success, Failure>` is an enum of two content traits:
 

--- a/screw-api/examples/json_api.rs
+++ b/screw-api/examples/json_api.rs
@@ -4,15 +4,20 @@
 //! serializes `ApiResponse` back out, so handlers only deal with their own
 //! types.
 //!
+//! A failure can come from either half, and both look the same from outside:
+//! `create` refuses a request it cannot build a content from; the handler
+//! answers for everything that depends on the value.
+//!
 //! ```sh
 //! cargo run -p screw-api --example json_api --features json
 //!
 //! curl -s localhost:8080/api/notes/1
+//! curl -s localhost:8080/api/notes/abc                 # BAD_ID, from `create`
 //! curl -s -X POST localhost:8080/api/notes \
 //!     -H 'Content-Type: application/json' -d '{"title":"first","body":"hi"}'
 //! curl -s -X POST localhost:8080/api/notes \
 //!     -H 'Content-Type: application/json' -d '{"title":"","body":"hi"}'
-//! curl -s -X POST localhost:8080/api/notes -d 'not json'   # wrong Content-Type
+//! curl -s -X POST localhost:8080/api/notes -d 'not json'   # MALFORMED_BODY
 //! ```
 
 use hyper::{Method, StatusCode};
@@ -22,7 +27,6 @@ use screw_api::request::{ApiRequest, ApiRequestContent, ApiRequestOriginContent}
 use screw_api::response::{
     ApiResponse, ApiResponseContentBase, ApiResponseContentFailure, ApiResponseContentSuccess,
 };
-use screw_components::dyn_result::DResult;
 use screw_core::request::Request;
 use screw_core::responder_factory::ResponderFactory;
 use screw_core::response::Response;
@@ -55,19 +59,28 @@ struct Extensions {
 
 // ---------------------------------------------------------------- requests
 
-/// `GET /api/notes/{id}` — no body, so `Data` is `()`.
+/// `GET /api/notes/{id}` — no body, so `Data` is `()`. An unparseable id is
+/// refused here rather than in the handler, which is why `id` is a `u64` and
+/// not an `Option<u64>`.
 struct ReadNoteContent {
-    id: Option<u64>,
+    id: u64,
     extensions: Arc<Extensions>,
 }
 
-impl ApiRequestContent<Extensions> for ReadNoteContent {
+impl ApiRequestContent<Extensions, NoteFailure> for ReadNoteContent {
     type Data = ();
-    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin.path.get("id").and_then(|id| id.parse().ok()),
+    fn create(
+        origin: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, NoteFailure> {
+        let id = origin
+            .path
+            .get("id")
+            .and_then(|id| id.parse().ok())
+            .ok_or(NoteFailure::BadId)?;
+        Ok(Self {
+            id,
             extensions: origin.extensions,
-        }
+        })
     }
 }
 
@@ -77,20 +90,28 @@ struct CreateNoteData {
     body: String,
 }
 
-/// `POST /api/notes` — the parsed body arrives as a `DResult`, so a malformed
-/// request is something the handler answers rather than a hard failure.
+/// `POST /api/notes` — a note without a readable body is nothing at all, so the
+/// body is settled here too and the handler gets a `CreateNoteData` rather than
+/// another `Result`. Carrying `data_result` on untouched stays the right answer
+/// when a bad body is *not* an unconditional refusal.
 struct CreateNoteContent {
-    data: DResult<CreateNoteData>,
+    data: CreateNoteData,
     extensions: Arc<Extensions>,
 }
 
-impl ApiRequestContent<Extensions> for CreateNoteContent {
+impl ApiRequestContent<Extensions, NoteFailure> for CreateNoteContent {
     type Data = CreateNoteData;
-    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            data: origin.data_result,
+    fn create(
+        origin: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, NoteFailure> {
+        // Wrong `Content-Type`, oversized, or unparseable body all land here.
+        let data = origin
+            .data_result
+            .map_err(|error| NoteFailure::MalformedBody(error.to_string()))?;
+        Ok(Self {
+            data,
             extensions: origin.extensions,
-        }
+        })
     }
 }
 
@@ -177,11 +198,13 @@ async fn read_note(
 ) -> Result<NoteSuccess, NoteFailure> {
     let content = request.content;
 
-    let Some(id) = content.id else {
-        return Err(NoteFailure::BadId);
-    };
-
-    let note = content.extensions.notes.lock().unwrap().get(&id).cloned();
+    let note = content
+        .extensions
+        .notes
+        .lock()
+        .unwrap()
+        .get(&content.id)
+        .cloned();
 
     note.map(NoteSuccess::Found).ok_or(NoteFailure::NotFound)
 }
@@ -190,13 +213,10 @@ async fn create_note(
     request: ApiRequest<CreateNoteContent, Extensions>,
 ) -> ApiResponse<NoteSuccess, NoteFailure> {
     let content = request.content;
+    let data = content.data;
 
-    let data = match content.data {
-        Ok(data) => data,
-        // Wrong `Content-Type`, oversized, or unparseable body all land here.
-        Err(error) => return ApiResponse::failure(NoteFailure::MalformedBody(error.to_string())),
-    };
-
+    // A rule about the value rather than the shape of the request, so it stays
+    // with the handler.
     if data.title.trim().is_empty() {
         return ApiResponse::failure(NoteFailure::EmptyTitle);
     }

--- a/screw-api/examples/typed_middleware.rs
+++ b/screw-api/examples/typed_middleware.rs
@@ -81,9 +81,14 @@ struct PlainContent {
     token: Option<String>,
 }
 
-impl ApiRequestContent<Extensions> for PlainContent {
+/// Generic over the failure type, because both endpoints below share this
+/// content and it never refuses a request itself.
+impl<Failure> ApiRequestContent<Extensions, Failure> for PlainContent
+where
+    Failure: ApiResponseContentFailure,
+{
     type Data = ();
-    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
+    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Result<Self, Failure> {
         let token = origin
             .http_parts
             .headers
@@ -91,10 +96,10 @@ impl ApiRequestContent<Extensions> for PlainContent {
             .and_then(|value| value.to_str().ok())
             .and_then(|value| value.strip_prefix("Bearer "))
             .map(str::to_owned);
-        Self {
+        Ok(Self {
             extensions: origin.extensions,
             token,
-        }
+        })
     }
 }
 
@@ -149,7 +154,7 @@ struct Auth;
 impl<Content, Extensions, Success, Failure>
     Middleware<Authed<Content, Extensions>, ApiResponse<Success, Failure>> for Auth
 where
-    Content: ApiRequestContent<Extensions> + Authorizable + Send + 'static,
+    Content: ApiRequestContent<Extensions, Failure> + Authorizable + Send + 'static,
     Extensions: Send + Sync + 'static,
     Success: ApiResponseContentSuccess + Send + 'static,
     Failure: ApiResponseContentFailure + AuthFailure + Send + 'static,

--- a/screw-api/src/json/middleware.rs
+++ b/screw-api/src/json/middleware.rs
@@ -37,8 +37,9 @@ impl<RqContent, Extensions, RsContentSuccess, RsContentFailure>
         response::ApiResponse<RsContentSuccess, RsContentFailure>,
     > for JsonApiMiddlewareConverter
 where
-    RqContent: request::ApiRequestContent<Extensions> + Send + 'static,
-    <RqContent as request::ApiRequestContent<Extensions>>::Data: Sync + Send + 'static,
+    RqContent: request::ApiRequestContent<Extensions, RsContentFailure> + Send + 'static,
+    <RqContent as request::ApiRequestContent<Extensions, RsContentFailure>>::Data:
+        Sync + Send + 'static,
     Extensions: Sync + Send + 'static,
     RsContentSuccess: response::ApiResponseContentSuccess + Send + 'static,
     RsContentFailure: response::ApiResponseContentFailure + Send + 'static,
@@ -70,7 +71,7 @@ where
         let (http_parts, http_body) = routed_request.origin.http.into_parts();
         let data_result = convert(&http_parts, http_body, self.max_body_size).await;
 
-        let request_content = RqContent::create(request::ApiRequestOriginContent {
+        let request_content_result = RqContent::create(request::ApiRequestOriginContent {
             path: routed_request.path,
             query: routed_request.query,
             http_parts,
@@ -79,12 +80,16 @@ where
             data_result,
         });
 
-        let api_request = request::ApiRequest {
-            content: request_content,
-            _p_e: Default::default(),
+        let api_response = match request_content_result {
+            Ok(request_content) => {
+                next(request::ApiRequest {
+                    content: request_content,
+                    _p_e: Default::default(),
+                })
+                .await
+            }
+            Err(failure) => response::ApiResponse::failure(failure),
         };
-
-        let api_response = next(api_request).await;
 
         let http_response_result: DResult<hyper::Response<ResponseBody>> = (|| {
             let content = api_response.content;

--- a/screw-api/src/request.rs
+++ b/screw-api/src/request.rs
@@ -1,3 +1,4 @@
+use crate::response::ApiResponseContentFailure;
 use hyper::http::request::Parts;
 use screw_components::dyn_result::DResult;
 use screw_core::routing::actix::Path;
@@ -27,28 +28,38 @@ where
 /// body and a body over the size limit all arrive here as an error rather than
 /// failing the request, so the handler decides what a bad body means for that
 /// endpoint.
-pub trait ApiRequestContent<Extensions> {
-    type Data: for<'de> Deserialize<'de>;
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self;
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for () {
-    type Data = ();
-    fn create(_origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {}
-}
-
-pub struct ApiRequest<Content, Extensions>
+///
+/// `create` may also refuse to build the content at all. `Failure` is the
+/// failure half of the response the handler answers with, so an `Err` is an
+/// ordinary failure response and the handler is never called.
+pub trait ApiRequestContent<Extensions, Failure>: Sized
 where
-    Content: ApiRequestContent<Extensions>,
+    Failure: ApiResponseContentFailure,
 {
+    type Data: for<'de> Deserialize<'de>;
+    fn create(
+        origin_content: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, Failure>;
+}
+
+impl<Extensions, Failure> ApiRequestContent<Extensions, Failure> for ()
+where
+    Failure: ApiResponseContentFailure,
+{
+    type Data = ();
+    fn create(
+        _origin_content: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, Failure> {
+        Ok(())
+    }
+}
+
+pub struct ApiRequest<Content, Extensions> {
     pub content: Content,
     pub(super) _p_e: PhantomData<Extensions>,
 }
 
-impl<Content, Extensions> From<ApiRequest<Content, Extensions>> for (Content,)
-where
-    Content: ApiRequestContent<Extensions>,
-{
+impl<Content, Extensions> From<ApiRequest<Content, Extensions>> for (Content,) {
     fn from(value: ApiRequest<Content, Extensions>) -> Self {
         (value.content,)
     }

--- a/screw-api/src/xml/middleware.rs
+++ b/screw-api/src/xml/middleware.rs
@@ -35,8 +35,9 @@ impl<RqContent, Extensions, RsContentSuccess, RsContentFailure>
         response::ApiResponse<RsContentSuccess, RsContentFailure>,
     > for XmlApiMiddlewareConverter
 where
-    RqContent: request::ApiRequestContent<Extensions> + Send + 'static,
-    <RqContent as request::ApiRequestContent<Extensions>>::Data: Sync + Send + 'static,
+    RqContent: request::ApiRequestContent<Extensions, RsContentFailure> + Send + 'static,
+    <RqContent as request::ApiRequestContent<Extensions, RsContentFailure>>::Data:
+        Sync + Send + 'static,
     Extensions: Sync + Send + 'static,
     RsContentSuccess: response::ApiResponseContentSuccess + Send + 'static,
     RsContentFailure: response::ApiResponseContentFailure + Send + 'static,
@@ -69,7 +70,7 @@ where
         let (http_parts, http_body) = routed_request.origin.http.into_parts();
         let data_result = convert(&http_parts, http_body, self.max_body_size).await;
 
-        let request_content = RqContent::create(request::ApiRequestOriginContent {
+        let request_content_result = RqContent::create(request::ApiRequestOriginContent {
             path: routed_request.path,
             query: routed_request.query,
             http_parts,
@@ -78,12 +79,16 @@ where
             data_result,
         });
 
-        let api_request = request::ApiRequest {
-            content: request_content,
-            _p_e: Default::default(),
+        let api_response = match request_content_result {
+            Ok(request_content) => {
+                next(request::ApiRequest {
+                    content: request_content,
+                    _p_e: Default::default(),
+                })
+                .await
+            }
+            Err(failure) => response::ApiResponse::failure(failure),
         };
-
-        let api_response = next(api_request).await;
 
         let http_response_result: DResult<hyper::Response<ResponseBody>> = (|| {
             let content = api_response.content;

--- a/screw-api/tests/end_to_end.rs
+++ b/screw-api/tests/end_to_end.rs
@@ -36,11 +36,30 @@ struct EchoContent {
     data: DResult<EchoData>,
 }
 
-impl ApiRequestContent<Extensions> for EchoContent {
+impl<Failure> ApiRequestContent<Extensions, Failure> for EchoContent
+where
+    Failure: ApiResponseContentFailure,
+{
     type Data = EchoData;
-    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
+    fn create(origin: ApiRequestOriginContent<Self::Data, Extensions>) -> Result<Self, Failure> {
+        Ok(Self {
             data: origin.data_result,
+        })
+    }
+}
+
+/// Refuses to be built when the request carries no `X-Echo` header.
+struct GuardedContent;
+
+impl ApiRequestContent<Extensions, EchoFailure> for GuardedContent {
+    type Data = ();
+    fn create(
+        origin: ApiRequestOriginContent<Self::Data, Extensions>,
+    ) -> Result<Self, EchoFailure> {
+        if origin.http_parts.headers.contains_key("x-echo") {
+            Ok(Self)
+        } else {
+            Err(EchoFailure("missing X-Echo".to_owned()))
         }
     }
 }
@@ -107,6 +126,14 @@ async fn echo_unpacked((content,): (EchoContent,)) -> Result<EchoSuccess, EchoFa
     }
 }
 
+async fn guarded(
+    _: ApiRequest<GuardedContent, Extensions>,
+) -> ApiResponse<EchoSuccess, EchoFailure> {
+    ApiResponse::success(EchoSuccess(Echoed {
+        message: "guarded".to_owned(),
+    }))
+}
+
 async fn fallback(_: RoutedRequest<ScrewRequest<Extensions>>) -> Response {
     Response {
         http: hyper::Response::builder()
@@ -133,6 +160,11 @@ async fn start_server() -> SocketAddr {
                 Route::with_method(&Method::POST)
                     .and_path("/echo-unpacked")
                     .and_handler(echo_unpacked),
+            )
+            .route(
+                Route::with_method(&Method::POST)
+                    .and_path("/guarded")
+                    .and_handler(guarded),
             )
         })
     });
@@ -174,6 +206,16 @@ async fn post_to(
     content_type: Option<&str>,
     body: &str,
 ) -> (StatusCode, hyper::HeaderMap, serde_json::Value) {
+    post_with_headers(addr, path, content_type, &[], body).await
+}
+
+async fn post_with_headers(
+    addr: SocketAddr,
+    path: &str,
+    content_type: Option<&str>,
+    extra_headers: &[(&str, &str)],
+    body: &str,
+) -> (StatusCode, hyper::HeaderMap, serde_json::Value) {
     let stream = TcpStream::connect(addr).await.unwrap();
     let (mut sender, connection) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
         .await
@@ -186,6 +228,9 @@ async fn post_to(
         .header(hyper::header::HOST, "localhost");
     if let Some(content_type) = content_type {
         builder = builder.header(hyper::header::CONTENT_TYPE, content_type);
+    }
+    for (name, value) in extra_headers {
+        builder = builder.header(*name, *value);
     }
     let request = builder
         .body(screw_core::body::full(body.to_owned()))
@@ -245,6 +290,39 @@ async fn an_err_from_such_a_handler_becomes_a_failure_response() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(json["failure"]["identifier"], "BAD_BODY");
+}
+
+#[tokio::test]
+async fn a_content_that_refuses_to_be_built_answers_as_a_failure() {
+    let addr = start_server().await;
+
+    let (status, headers, json) =
+        post_with_headers(addr, "/api/guarded", Some("application/json"), &[], "{}").await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        headers.get(hyper::header::CONTENT_TYPE).unwrap(),
+        "application/json"
+    );
+    assert_eq!(json["failure"]["identifier"], "BAD_BODY");
+    assert_eq!(json["failure"]["reason"], "missing X-Echo");
+}
+
+#[tokio::test]
+async fn the_handler_runs_once_the_content_is_built() {
+    let addr = start_server().await;
+
+    let (status, _, json) = post_with_headers(
+        addr,
+        "/api/guarded",
+        Some("application/json"),
+        &[("x-echo", "yes")],
+        "{}",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"]["data"]["message"], "guarded");
 }
 
 #[tokio::test]

--- a/screw-api/tests/middleware_nesting.rs
+++ b/screw-api/tests/middleware_nesting.rs
@@ -13,19 +13,24 @@ use screw_core::routing::router::{self, RoutedRequest};
 
 struct Extensions;
 
+// `ContentA` is generic over the failure type and `ContentB` names one, on
+// purpose: routing has to resolve `Data` through either kind of impl.
 struct ContentA;
-impl ApiRequestContent<Extensions> for ContentA {
+impl<Failure> ApiRequestContent<Extensions, Failure> for ContentA
+where
+    Failure: ApiResponseContentFailure,
+{
     type Data = ();
-    fn create(_: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        ContentA
+    fn create(_: ApiRequestOriginContent<Self::Data, Extensions>) -> Result<Self, Failure> {
+        Ok(ContentA)
     }
 }
 
 struct ContentB;
-impl ApiRequestContent<Extensions> for ContentB {
+impl ApiRequestContent<Extensions, FailureB> for ContentB {
     type Data = ();
-    fn create(_: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        ContentB
+    fn create(_: ApiRequestOriginContent<Self::Data, Extensions>) -> Result<Self, FailureB> {
+        Ok(ContentB)
     }
 }
 
@@ -76,10 +81,7 @@ success!(SuccessB, "B");
 failure!(FailureA, "A_ERR");
 failure!(FailureB, "B_ERR");
 
-struct Authed<Content, Extensions>
-where
-    Content: ApiRequestContent<Extensions>,
-{
+struct Authed<Content, Extensions> {
     #[allow(dead_code)]
     request: ApiRequest<Content, Extensions>,
 }
@@ -89,7 +91,7 @@ struct Auth;
 impl<Content, Ext, Success, Failure> Middleware<Authed<Content, Ext>, ApiResponse<Success, Failure>>
     for Auth
 where
-    Content: ApiRequestContent<Ext> + Send + 'static,
+    Content: ApiRequestContent<Ext, Failure> + Send + 'static,
     Ext: Send + Sync + 'static,
     Success: ApiResponseContentSuccess + Send + 'static,
     Failure: ApiResponseContentFailure + Send + 'static,


### PR DESCRIPTION
ApiRequestContent::create returned Self, so the only way an endpoint could reject a request before its handler ran was to carry the problem into the content and re-check it there: an id that will not parse became an Option<u64> that every handler sharing the content had to destructure again. Middleware is the framework's answer to refusing early, but it is registered per scope, so it cannot speak about one route's path parameters. create now returns Result<Self, Failure>, and an Err is an ordinary failure response with the handler never called.

Failure is a parameter of the trait rather than an associated type because the converter is the only place the request and response halves meet, and it can then require the two to agree exactly. An associated type would have to be bridged with RsContentFailure: From<Content:: Failure>, which collapses on the common case: a content that never fails names Infallible, std has no blanket From<Infallible>, and every failure enum in every application would need a hand-written impl to satisfy a conversion that is never performed.

Body handling is deliberately unchanged. data_result is still a DResult<Data>, so the converter still refuses to decide what a bad body means; a content that cannot do without one now has the option of map_err-ing it into a failure, which is what the json_api example does.

ApiRequest loses its ApiRequestContent bound. It stores a content and a PhantomData and never used the trait, and the alternative was a third type parameter on a public type for nothing.

The cost is diagnostic. If a content names one failure type and the handler answers with another, inference carries the mismatch into the response position and it surfaces at route(...) as an unsatisfied From<ApiResponse<_, _>> bound, naming neither create nor the content. A content that cannot fail avoids this entirely by staying generic over Failure, so PlainContent, EchoContent and ContentA are written that way, and ContentB is left concrete so routing is still covered resolving Data through both kinds of impl. The bound on the trait itself is what keeps an outright wrong Failure an error at the impl instead of at the route.

Covered end to end: a content refusing on a missing header answers 400 through the normal JSON path, and the handler runs once it is built. The json_api example was driven against a live server for all four outcomes -- BAD_ID and MALFORMED_BODY from create, EMPTY_TITLE from the handler, and the two successes.